### PR TITLE
show frontend errors properly

### DIFF
--- a/client/src/routes/+error.svelte
+++ b/client/src/routes/+error.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
     import { page } from '$app/stores';
 
-    const errors = $page.error?.errors;
+    const message = $page.error?.error;
+    const details = $page.error?.details;
     const status = $page.status
 </script>
   
 <h1 class="container">
     <h1>{status}</h1>
-    {#each errors || [] as error}
-        <div>{error}</div>
+    <h5>{message}</h5>
+    {#each details || [] as detail}
+        <div>{detail}</div>
     {/each}
 </h1>
 

--- a/client/src/routes/[username]/+page.server.ts
+++ b/client/src/routes/[username]/+page.server.ts
@@ -7,23 +7,23 @@ export const load = (async ({ fetch, params }) => {
 
   const { username } = params;
 
-  const comics_res = await fetch(`http://localhost:6060/api/v1/users/comics/${username}`, {
+  const comicsRes = await fetch(`http://localhost:6060/api/v1/users/comics/${username}`, {
     credentials: "include",
   });
-  if (comics_res.status != 200) {
-    const res_error = await comics_res.json().catch(() => ({ error: comics_res.statusText }));
-    throw error(comics_res.status, res_error);
+  if (comicsRes.status != 200) {
+    const resError = await comicsRes.json().catch(() => ({ error: comicsRes.statusText }));
+    throw error(comicsRes.status, resError);
   }
-  const comics: ComicResponse[] = await comics_res.json();
+  const comics: ComicResponse[] = await comicsRes.json();
 
-  const user_res = await fetch(`http://localhost:6060/api/v1/users/${username}`, {
+  const userRes = await fetch(`http://localhost:6060/api/v1/users/${username}`, {
     credentials: "include",
   });
-  if (user_res.status != 200) {
-    const res_error = await user_res.json().catch(() => ({ error: user_res.statusText }));
-    throw error(user_res.status, res_error);
+  if (userRes.status != 200) {
+    const resError = await userRes.json().catch(() => ({ error: userRes.statusText }));
+    throw error(userRes.status, resError);
   }
-  const user: UserResponse = await user_res.json();
+  const user: UserResponse = await userRes.json();
 
   return {
     comics,

--- a/client/src/routes/[username]/+page.server.ts
+++ b/client/src/routes/[username]/+page.server.ts
@@ -7,23 +7,23 @@ export const load = (async ({ fetch, params }) => {
 
   const { username } = params;
 
-  const comicsRes = await fetch(`http://localhost:6060/api/v1/users/comics/${username}`, {
+  const comics_res = await fetch(`http://localhost:6060/api/v1/users/comics/${username}`, {
     credentials: "include",
   });
-  if (comicsRes.status != 200) {
-    const errorMessage = await comicsRes.json();
-    throw error(comicsRes.status, errorMessage.error);
+  if (comics_res.status != 200) {
+    const res_error = await comics_res.json().catch(() => ({ error: comics_res.statusText }));
+    throw error(comics_res.status, res_error);
   }
-  const comics: ComicResponse[] = await comicsRes.json();
+  const comics: ComicResponse[] = await comics_res.json();
 
-  const userRes = await fetch(`http://localhost:6060/api/v1/users/${username}`, {
+  const user_res = await fetch(`http://localhost:6060/api/v1/users/${username}`, {
     credentials: "include",
   });
-  if (userRes.status != 200) {
-    const errorMessage = await userRes.json();
-    throw error(userRes.status, errorMessage.error);
+  if (user_res.status != 200) {
+    const res_error = await user_res.json().catch(() => ({ error: user_res.statusText }));
+    throw error(user_res.status, res_error);
   }
-  const user: UserResponse = await userRes.json();
+  const user: UserResponse = await user_res.json();
 
   return {
     comics,

--- a/client/src/routes/[username]/[comic_slug]/+page.server.ts
+++ b/client/src/routes/[username]/[comic_slug]/+page.server.ts
@@ -6,23 +6,23 @@ import type { ComicCommentResponse } from 'bindings/ComicCommentResponse';
 export const load = (async ({ fetch, params }) => {
     const { comic_slug, username } = params;
 
-    const comic_res = await fetch(`http://localhost:6060/api/v1/comics/by_slug/${comic_slug}/${username}`);
+    const comicRes = await fetch(`http://localhost:6060/api/v1/comics/by_slug/${comic_slug}/${username}`);
 
-    if (comic_res.status != 200) {
-        const res_error = await comic_res.json().catch(() => ({ error: comic_res.statusText }));
-        throw error(comic_res.status, res_error);
+    if (comicRes.status != 200) {
+        const resError = await comicRes.json().catch(() => ({ error: comicRes.statusText }));
+        throw error(comicRes.status, resError);
     }
 
-    const comic: ComicResponse = await comic_res.json();
+    const comic: ComicResponse = await comicRes.json();
 
-    const comment_res = await fetch(`http://localhost:6060/api/v1/comics/${comic.id}/comments`);
+    const commentRes = await fetch(`http://localhost:6060/api/v1/comics/${comic.id}/comments`);
 
-    if (comment_res.status != 200) {
-        const res_error = await comment_res.json().catch(() => ({ error: comment_res.statusText }));
-        throw error(comment_res.status, res_error);
+    if (commentRes.status != 200) {
+        const resError = await commentRes.json().catch(() => ({ error: commentRes.statusText }));
+        throw error(commentRes.status, resError);
     }
 
-    let comments: ComicCommentResponse[] = await comment_res.json();
+    let comments: ComicCommentResponse[] = await commentRes.json();
 
     let top_level_comments: ComicCommentResponse[] = comments.filter((comment) => {
         return comment.parent_comment === null;

--- a/client/src/routes/[username]/[comic_slug]/+page.server.ts
+++ b/client/src/routes/[username]/[comic_slug]/+page.server.ts
@@ -9,8 +9,8 @@ export const load = (async ({ fetch, params }) => {
     const comic_res = await fetch(`http://localhost:6060/api/v1/comics/by_slug/${comic_slug}/${username}`);
 
     if (comic_res.status != 200) {
-        const errorMessage = await comic_res.json();
-        throw error(comic_res.status, errorMessage);
+        const res_error = await comic_res.json().catch(() => ({ error: comic_res.statusText }));
+        throw error(comic_res.status, res_error);
     }
 
     const comic: ComicResponse = await comic_res.json();
@@ -18,8 +18,8 @@ export const load = (async ({ fetch, params }) => {
     const comment_res = await fetch(`http://localhost:6060/api/v1/comics/${comic.id}/comments`);
 
     if (comment_res.status != 200) {
-        const errorMessage = await comment_res.json();
-        throw error(comment_res.status, errorMessage);
+        const res_error = await comment_res.json().catch(() => ({ error: comment_res.statusText }));
+        throw error(comment_res.status, res_error);
     }
 
     let comments: ComicCommentResponse[] = await comment_res.json();

--- a/client/src/routes/[username]/[comic_slug]/[chapter_number]/+page.server.ts
+++ b/client/src/routes/[username]/[comic_slug]/[chapter_number]/+page.server.ts
@@ -8,8 +8,8 @@ export const load = (async ({ fetch, params }) => {
     const res = await fetch(`http://localhost:6060/api/v1/comics/chapters/by_slug/${username}/${comic_slug}/${chapter_number}/`);
 
     if (res.status != 200) {
-        const errorMessage = await res.json();
-        throw error(res.status, errorMessage);
+        const res_error = await res.json().catch(() => ({ error: res.statusText }));
+        throw error(res.status, res_error);
     }
 
     const data: ChapterResponse = await res.json();

--- a/client/src/routes/[username]/[comic_slug]/[chapter_number]/+page.server.ts
+++ b/client/src/routes/[username]/[comic_slug]/[chapter_number]/+page.server.ts
@@ -8,8 +8,8 @@ export const load = (async ({ fetch, params }) => {
     const res = await fetch(`http://localhost:6060/api/v1/comics/chapters/by_slug/${username}/${comic_slug}/${chapter_number}/`);
 
     if (res.status != 200) {
-        const res_error = await res.json().catch(() => ({ error: res.statusText }));
-        throw error(res.status, res_error);
+        const resError = await res.json().catch(() => ({ error: res.statusText }));
+        throw error(res.status, resError);
     }
 
     const data: ChapterResponse = await res.json();

--- a/client/src/routes/[username]/[comic_slug]/[chapter_number]/chapter-settings/+page.ts
+++ b/client/src/routes/[username]/[comic_slug]/[chapter_number]/chapter-settings/+page.ts
@@ -14,8 +14,8 @@ export const load = (async ({ fetch, params, depends }) => {
     if (res.status === 401) {
         throw redirect(307, "/");
     } else if (res.status !== 200) {
-        const errorMessage = await res.json();
-        throw error(res.status, errorMessage.error);
+        const res_error = await res.json().catch(() => ({ error: res.statusText }));
+        throw error(res.status, res_error);
     }
 
     const chapter: ChapterResponse = await res.json();

--- a/client/src/routes/[username]/[comic_slug]/[chapter_number]/chapter-settings/+page.ts
+++ b/client/src/routes/[username]/[comic_slug]/[chapter_number]/chapter-settings/+page.ts
@@ -14,8 +14,8 @@ export const load = (async ({ fetch, params, depends }) => {
     if (res.status === 401) {
         throw redirect(307, "/");
     } else if (res.status !== 200) {
-        const res_error = await res.json().catch(() => ({ error: res.statusText }));
-        throw error(res.status, res_error);
+        const resError = await res.json().catch(() => ({ error: res.statusText }));
+        throw error(res.status, resError);
     }
 
     const chapter: ChapterResponse = await res.json();

--- a/client/src/routes/[username]/[comic_slug]/new-chapter/+page.ts
+++ b/client/src/routes/[username]/[comic_slug]/new-chapter/+page.ts
@@ -10,8 +10,8 @@ export const load = (async ({ params }) => {
     });
 
     if (res.status !== 200) {
-        const res_error = await res.json().catch(() => ({ error: res.statusText }));
-        throw error(res.status, res_error);
+        const resError = await res.json().catch(() => ({ error: res.statusText }));
+        throw error(res.status, resError);
     }
 
     const comic: ComicResponse = await res.json();

--- a/client/src/routes/[username]/[comic_slug]/new-chapter/+page.ts
+++ b/client/src/routes/[username]/[comic_slug]/new-chapter/+page.ts
@@ -10,7 +10,8 @@ export const load = (async ({ params }) => {
     });
 
     if (res.status !== 200) {
-        throw error(res.status, await res.json());
+        const res_error = await res.json().catch(() => ({ error: res.statusText }));
+        throw error(res.status, res_error);
     }
 
     const comic: ComicResponse = await res.json();

--- a/client/src/routes/new-comic/+page.ts
+++ b/client/src/routes/new-comic/+page.ts
@@ -6,8 +6,8 @@ export const load = (async ({ fetch }) => {
     const res = await fetch("http://localhost:6060/api/v1/comics/genres");
 
     if (res.status !== 200) {
-        const res_error = await res.json().catch(() => ({ error: res.statusText }));
-        throw error(res.status, res_error);
+        const resError = await res.json().catch(() => ({ error: res.statusText }));
+        throw error(res.status, resError);
     }
 
     const genres: ComicGenre[] = await res.json();

--- a/client/src/routes/new-comic/+page.ts
+++ b/client/src/routes/new-comic/+page.ts
@@ -6,8 +6,8 @@ export const load = (async ({ fetch }) => {
     const res = await fetch("http://localhost:6060/api/v1/comics/genres");
 
     if (res.status !== 200) {
-        const errorMessage = await res.json();
-        throw error(res.status, errorMessage.error);
+        const res_error = await res.json().catch(() => ({ error: res.statusText }));
+        throw error(res.status, res_error);
     }
 
     const genres: ComicGenre[] = await res.json();


### PR DESCRIPTION
- fix error display in `error.svelte`
- if no json error is returned by backend, return `statusText` as error message

fixes #53 