### PR TITLE
only refresh unexpired sessions, and refactor AuthExtractor

### DIFF
--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -105,10 +105,14 @@ pub async fn refresh_session<B>(
     let mut db = state.pool.get().await?;
 
     if let Some(session_id) = session.session_id {
-        diesel::update(sessions::table.find(session_id))
-            .set(sessions::expires_at.eq(Utc::now() + Duration::days(2)))
-            .execute(&mut db)
-            .await?;
+        diesel::update(
+            sessions::table
+                .filter(sessions::id.eq(session_id))
+                .filter(sessions::expires_at.gt(Utc::now())),
+        )
+        .set(sessions::expires_at.eq(Utc::now() + Duration::days(2)))
+        .execute(&mut db)
+        .await?;
     }
 
     Ok(next.run(request).await)

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -21,7 +21,7 @@ use crate::{schema::sessions, AppState, ErrorResponse, InnerAppState};
 pub const SESSION_COOKIE_NAME: &str = "session_id";
 
 pub struct UserSession {
-    session_id: Option<Uuid>,
+    pub session_id: Option<Uuid>,
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
- only refresh unexpired sessions.
- reuse the `UserSession` extractor in `AuthExtractor` to extract the `session_id` from the headers.
- remove the cookie removal on invalid session, because we mostly call backend endpoints from `page.server.ts` and `page.ts`, which doesn't forward the `set-cookie` header to the client. I'm not sure if svelte hooks _might_ solve this, needs investigation.

fixes #37 