### PR TITLE
pagination and other stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +421,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "headers",
@@ -501,6 +510,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +566,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "blake2"
@@ -858,11 +888,11 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72eb77396836a4505da85bae0712fa324b74acfe1876d7c2f7e694ef3d0ee373"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -873,14 +903,14 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5897424d8409385a0cc83d64a44527d15bedb5e3797b65f99daf46374eb6df8e"
+checksum = "c7e7974099f0d9bde0e010dd3a673555276a474f3362a7a52ab535a57b7c5056"
 dependencies = [
  "async-trait",
  "deadpool",
  "diesel",
- "futures",
+ "futures-util",
  "scoped-futures",
  "tokio",
  "tokio-postgres",
@@ -888,26 +918,36 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
+checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
 dependencies = [
- "proc-macro-error",
+ "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "diesel_migrations_async"
 version = "0.1.0"
-source = "git+https://github.com/aumetra/diesel_migrations_async#fdde99d8fd62559f74efdc247bf7f3ec99ec6df8"
+source = "git+https://github.com/aumetra/diesel_migrations_async#15a910802185a47fd2e76a100769ef150b0fe065"
 dependencies = [
  "async-trait",
  "diesel",
  "diesel-async",
  "migrations_internals",
  "migrations_macros",
+ "tokio",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1206,6 +1246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "h2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,7 +1283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -1517,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linked-hash-map"
@@ -1603,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "migrations_internals"
 version = "0.1.0"
-source = "git+https://github.com/aumetra/diesel_migrations_async#fdde99d8fd62559f74efdc247bf7f3ec99ec6df8"
+source = "git+https://github.com/aumetra/diesel_migrations_async#15a910802185a47fd2e76a100769ef150b0fe065"
 dependencies = [
  "serde",
  "toml",
@@ -1612,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "migrations_macros"
 version = "0.1.0"
-source = "git+https://github.com/aumetra/diesel_migrations_async#fdde99d8fd62559f74efdc247bf7f3ec99ec6df8"
+source = "git+https://github.com/aumetra/diesel_migrations_async#15a910802185a47fd2e76a100769ef150b0fe065"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -1776,6 +1822,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2116,7 +2171,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2125,7 +2180,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2261,6 +2316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,7 +2336,7 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2410,7 +2471,7 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2753,11 +2814,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2925,7 +2987,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ axum-extra = { version = "0.7.4" }
 time = "0.3.21"
 tower-cookies = { version = "0.9.0", features = ["private"] }
 tracing-appender = "0.2.2"
-diesel = { version = "2.0.4", features = ["postgres", "chrono", "uuid"] }
-diesel-async = { version = "0.2.2", features = ["tokio-postgres", "deadpool"] }
+diesel = { version = "2.1.0", features = ["postgres", "chrono", "uuid"] }
+diesel-async = { version = "0.3.2", features = ["tokio-postgres", "deadpool"] }
 diesel_migrations_async = { git = "https://github.com/aumetra/diesel_migrations_async", features = ["postgres"] }
 toml = "0.7.4"
 lettre = { version = "0.10.4", default-features = false, features = ["tokio1", "tokio1-rustls-tls", "smtp-transport", "builder"] }

--- a/client/src/routes/[username]/+page.server.ts
+++ b/client/src/routes/[username]/+page.server.ts
@@ -1,20 +1,11 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import type { ComicResponse } from 'bindings/ComicResponse';
+import type { ComicResponseBrief } from 'bindings/ComicResponseBrief';
 import type { UserResponse } from 'bindings/UserResponse';
 
 export const load = (async ({ fetch, params }) => {
 
   const { username } = params;
-
-  const comicsRes = await fetch(`http://localhost:6060/api/v1/users/comics/${username}`, {
-    credentials: "include",
-  });
-  if (comicsRes.status != 200) {
-    const resError = await comicsRes.json().catch(() => ({ error: comicsRes.statusText }));
-    throw error(comicsRes.status, resError);
-  }
-  const comics: ComicResponse[] = await comicsRes.json();
 
   const userRes = await fetch(`http://localhost:6060/api/v1/users/${username}`, {
     credentials: "include",
@@ -24,6 +15,16 @@ export const load = (async ({ fetch, params }) => {
     throw error(userRes.status, resError);
   }
   const user: UserResponse = await userRes.json();
+
+  const comicsRes = await fetch(`http://localhost:6060/api/v1/users/comics/${user.id}`, {
+    credentials: "include",
+  });
+  if (comicsRes.status != 200) {
+    const resError = await comicsRes.json().catch(() => ({ error: comicsRes.statusText }));
+    throw error(comicsRes.status, resError);
+  }
+  const comics: ComicResponseBrief[] = await comicsRes.json();
+
 
   return {
     comics,

--- a/src/comics/chapters/models.rs
+++ b/src/comics/chapters/models.rs
@@ -21,6 +21,7 @@ use crate::{
 #[diesel(belongs_to(User))]
 #[diesel(belongs_to(Comic))]
 #[diesel(table_name = comic_chapters)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Chapter {
     pub id: Uuid,
     pub title: String,
@@ -92,6 +93,7 @@ impl Chapter {
 #[diesel(belongs_to(Chapter))]
 #[diesel(belongs_to(User))]
 #[diesel(table_name = chapter_pages)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ChapterPage {
     pub id: Uuid,
     pub number: i32,
@@ -109,6 +111,7 @@ pub struct ChapterPage {
 #[diesel(belongs_to(User))]
 #[diesel(belongs_to(Chapter))]
 #[diesel(table_name = chapter_ratings)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ChapterRating {
     pub id: Uuid,
     pub rating: f64,
@@ -134,6 +137,7 @@ pub struct CreateChapter {
 
 #[derive(AsChangeset, Deserialize, ToSchema, Debug, TS)]
 #[diesel(table_name = comic_chapters)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 #[ts(export)]
 pub struct UpdateChapter {
     pub title: Option<String>,
@@ -143,6 +147,7 @@ pub struct UpdateChapter {
 
 #[derive(AsChangeset, Deserialize, ToSchema, Debug, TS)]
 #[diesel(table_name = chapter_pages)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 #[ts(export)]
 pub struct UpdateChapterPage {
     pub description: Option<String>,

--- a/src/comics/chapters/routes.rs
+++ b/src/comics/chapters/routes.rs
@@ -581,6 +581,7 @@ pub async fn rate_chapter(
 }
 
 /// Get chapters of a comic with pagination
+// TODO: remove later if not used
 #[utoipa::path(
     get,
     path = "/api/v1/comics/:comic_id/chapters",

--- a/src/comics/comic_comments/models.rs
+++ b/src/comics/comic_comments/models.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 #[diesel(belongs_to(User))]
 #[diesel(belongs_to(Comic))]
 #[diesel(table_name = comic_comments)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ComicComment {
     pub id: Uuid,
     pub content: String,
@@ -27,6 +28,7 @@ pub struct ComicComment {
 #[diesel(belongs_to(ComicComment, foreign_key = parent_comment_id))]
 #[diesel(table_name = comic_comments_mapping)]
 #[diesel(primary_key(parent_comment_id, child_comment_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ComicCommentMapping {
     pub parent_comment_id: Uuid,
     pub child_comment_id: Uuid,

--- a/src/comics/comic_genres/models.rs
+++ b/src/comics/comic_genres/models.rs
@@ -12,6 +12,7 @@ use crate::{
 
 #[derive(Queryable, Selectable, Identifiable, Debug, ToSchema, PartialEq)]
 #[diesel(table_name = comic_genres)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Genre {
     pub id: i32,
     pub name: String,
@@ -23,6 +24,7 @@ pub struct Genre {
 #[diesel(belongs_to(Genre))]
 #[diesel(table_name = comic_genres_mapping)]
 #[diesel(primary_key(comic_id, genre_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct GenreMapping {
     pub comic_id: Uuid,
     pub genre_id: i32,
@@ -42,6 +44,7 @@ pub struct CreateComicGenre {
 
 #[derive(AsChangeset, Debug, Serialize, Deserialize, ToSchema, TS, PartialEq)]
 #[diesel(table_name = comic_genres)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct UpdateComicGenre {
     pub name: Option<String>,
     pub created_at: Option<DateTime<chrono::Utc>>,
@@ -49,6 +52,7 @@ pub struct UpdateComicGenre {
 
 #[derive(Insertable, Debug, PartialEq)]
 #[diesel(table_name = comic_genres)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ComicGenreInsert {
     pub name: String,
     pub created_at: DateTime<chrono::Utc>,

--- a/src/comics/mod.rs
+++ b/src/comics/mod.rs
@@ -1,7 +1,9 @@
 use axum::{http::StatusCode, response::IntoResponse};
+use chrono::{DateTime, Utc};
 use diesel::result::{DatabaseErrorKind, Error::DatabaseError};
 use diesel_async::pooled_connection::deadpool::PoolError;
 use serde::Deserialize;
+use serde::Serialize;
 use utoipa::IntoParams;
 use uuid::Uuid;
 
@@ -18,14 +20,37 @@ mod utils;
 
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ComicsParams {
-    #[serde(default = "Uuid::nil")]
-    pub min_id: Uuid,
     #[serde(default = "Uuid::max")]
     pub max_id: Uuid,
     #[serde(default)]
     pub genre: Option<i32>,
     #[serde(default)]
     pub sorting: Option<SortingOrder>,
+    #[serde(default)]
+    pub order: Order,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Order {
+    Latest(DateTime<chrono::Utc>),
+    Best(f64),
+}
+
+impl Default for Order {
+    fn default() -> Self {
+        Self::Latest(Utc::now())
+    }
+}
+
+impl Default for ComicsParams {
+    fn default() -> Self {
+        ComicsParams {
+            max_id: Uuid::max(),
+            genre: Option::default(),
+            order: Order::default(),
+            sorting: Option::default(),
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/comics/mod.rs
+++ b/src/comics/mod.rs
@@ -1,13 +1,8 @@
 use axum::{http::StatusCode, response::IntoResponse};
-use chrono::{DateTime, Utc};
 use diesel::result::{DatabaseErrorKind, Error::DatabaseError};
 use diesel_async::pooled_connection::deadpool::PoolError;
-use serde::Deserialize;
-use serde::Serialize;
-use utoipa::IntoParams;
-use uuid::Uuid;
 
-use crate::{ErrorResponse, SortingOrder};
+use crate::ErrorResponse;
 
 use self::chapters::routes::FILE_SIZE_LIMIT_MB;
 
@@ -17,42 +12,6 @@ pub mod comic_genres;
 pub mod models;
 pub mod routes;
 mod utils;
-
-#[derive(Debug, Deserialize, IntoParams)]
-pub struct ComicsParams {
-    #[serde(default = "Uuid::max")]
-    pub max_id: Uuid,
-    #[serde(default)]
-    pub genre: Option<i32>,
-    #[serde(default)]
-    pub sorting: Option<SortingOrder>,
-    #[serde(default)]
-    pub order: Order,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Order {
-    Latest(DateTime<chrono::Utc>),
-    Best(f64),
-}
-
-impl Default for Order {
-    fn default() -> Self {
-        Self::Latest(Utc::now())
-    }
-}
-
-impl Default for ComicsParams {
-    fn default() -> Self {
-        ComicsParams {
-            max_id: Uuid::max(),
-            genre: Option::default(),
-            order: Order::default(),
-            sorting: Option::default(),
-        }
-    }
-}
 
 #[derive(thiserror::Error, Debug)]
 pub enum ComicsError {

--- a/src/comics/mod.rs
+++ b/src/comics/mod.rs
@@ -31,6 +31,7 @@ pub struct ComicsParams {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Order {
     Latest(DateTime<chrono::Utc>),
     Best(f64),

--- a/src/comics/models.rs
+++ b/src/comics/models.rs
@@ -1,8 +1,8 @@
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::{
@@ -10,7 +10,7 @@ use crate::{
     comics::comic_genres::models::ComicGenre,
     schema::{comic_ratings, comics},
     users::models::{User, UserResponseBrief},
-    Rating,
+    Rating, SortingOrder,
 };
 
 use super::{
@@ -61,6 +61,46 @@ pub struct ComicResponseBrief {
     pub chapters_count: i64,
     pub created_at: String,
     pub genres: Vec<ComicGenre>,
+}
+
+#[derive(Debug, Deserialize, ToSchema, TS)]
+#[ts(export)]
+pub struct ComicsPagination {
+    #[serde(default = "Uuid::max")]
+    pub max_id: Uuid,
+    #[serde(default)]
+    pub order: Order,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ComicsParams {
+    #[serde(default)]
+    pub genre: Option<i32>,
+    #[serde(default)]
+    pub sorting: Option<SortingOrder>,
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export)]
+pub enum Order {
+    Latest(DateTime<chrono::Utc>),
+    Best(f64),
+}
+
+impl Default for Order {
+    fn default() -> Self {
+        Self::Latest(Utc::now())
+    }
+}
+
+impl Default for ComicsPagination {
+    fn default() -> Self {
+        ComicsPagination {
+            max_id: Uuid::max(),
+            order: Order::default(),
+        }
+    }
 }
 
 impl Comic {

--- a/src/comics/models.rs
+++ b/src/comics/models.rs
@@ -31,7 +31,7 @@ pub struct Comic {
     pub user_id: Uuid,
 }
 
-#[derive(Serialize, Deserialize, ToSchema, TS)]
+#[derive(Serialize, ToSchema, TS)]
 #[ts(export)]
 pub struct ComicResponse {
     pub id: Uuid,
@@ -42,6 +42,19 @@ pub struct ComicResponse {
     pub created_at: String,
     pub author: UserResponseBrief,
     pub chapters: Vec<ChapterResponseBrief>,
+    pub genres: Vec<ComicGenre>,
+}
+
+#[derive(Serialize, ToSchema, TS)]
+#[ts(export)]
+pub struct ComicResponseBrief {
+    pub id: Uuid,
+    pub title: String,
+    pub slug: String,
+    pub description: Option<String>,
+    pub rating: f64,
+    pub chapters_count: i64,
+    pub created_at: String,
     pub genres: Vec<ComicGenre>,
 }
 

--- a/src/comics/models.rs
+++ b/src/comics/models.rs
@@ -16,6 +16,7 @@ use crate::{
 #[derive(Insertable, Queryable, Selectable, Associations, Identifiable, Debug, Clone)]
 #[diesel(belongs_to(User))]
 #[diesel(table_name = comics)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Comic {
     pub id: Uuid,
     pub title: String,
@@ -48,6 +49,7 @@ pub struct ComicResponse {
 #[diesel(belongs_to(User))]
 #[diesel(belongs_to(Comic))]
 #[diesel(table_name = comic_ratings)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ComicRating {
     pub id: Uuid,
     pub rating: f64,
@@ -74,6 +76,7 @@ pub struct CreateComic {
 
 #[derive(AsChangeset, Deserialize, ToSchema)]
 #[diesel(table_name = comics)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct UpdateComic {
     pub title: Option<String>,
     pub description: Option<String>,

--- a/src/comics/models.rs
+++ b/src/comics/models.rs
@@ -13,6 +13,11 @@ use crate::{
     Rating,
 };
 
+use super::{
+    chapters::models::{Chapter, ChapterPage},
+    comic_genres::models::Genre,
+};
+
 #[derive(Insertable, Queryable, Selectable, Associations, Identifiable, Debug, Clone)]
 #[diesel(belongs_to(User))]
 #[diesel(table_name = comics)]
@@ -56,6 +61,61 @@ pub struct ComicResponseBrief {
     pub chapters_count: i64,
     pub created_at: String,
     pub genres: Vec<ComicGenre>,
+}
+
+impl Comic {
+    pub fn into_resonse(
+        self,
+        user: UserResponseBrief,
+        genres: Vec<Genre>,
+        chapter_and_pages: Vec<(Chapter, Vec<ChapterPage>)>,
+        rating: f64,
+    ) -> ComicResponse {
+        ComicResponse {
+            id: self.id,
+            title: self.title,
+            slug: self.slug,
+            description: self.description,
+            created_at: self.created_at.to_string(),
+            rating,
+            author: user,
+            chapters: chapter_and_pages
+                .into_iter()
+                .map(|(chapter, pages)| chapter.into_response_brief(pages))
+                .collect(),
+            genres: genres
+                .into_iter()
+                .map(|genre| ComicGenre {
+                    id: genre.id,
+                    name: genre.name,
+                })
+                .collect(),
+        }
+    }
+
+    pub fn into_response_brief(
+        self,
+        genres: Vec<Genre>,
+        chapters_count: i64,
+        rating: f64,
+    ) -> ComicResponseBrief {
+        ComicResponseBrief {
+            id: self.id,
+            title: self.title,
+            slug: self.slug,
+            description: self.description,
+            rating,
+            chapters_count,
+            created_at: self.created_at.to_string(),
+            genres: genres
+                .into_iter()
+                .map(|genre| ComicGenre {
+                    id: genre.id,
+                    name: genre.name,
+                })
+                .collect(),
+        }
+    }
 }
 
 #[derive(Insertable, Queryable, Selectable, Identifiable, Associations, Debug, PartialEq)]

--- a/src/comics/routes.rs
+++ b/src/comics/routes.rs
@@ -293,11 +293,11 @@ pub async fn get_comics(
         .select((Comic::as_select(), User::as_select(), average_rating));
 
     let (comics, users, ratings): (Vec<Comic>, Vec<User>, Vec<f64>) = match params.order {
-        Order::Latest(prev_time) => {
+        Order::Latest(prev_date) => {
             let query = query
                 .filter(
-                    comics::created_at.lt(prev_time).or(comics::created_at
-                        .eq(prev_time)
+                    comics::created_at.lt(prev_date).or(comics::created_at
+                        .eq(prev_date)
                         .and(comics::id.lt(params.max_id))),
                 )
                 .order((comics::created_at.desc(), comics::id.desc()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 use std::{fmt::Display, fs, sync::Arc};
 
 use axum::{extract::FromRef, response::IntoResponse};
+use diesel::{
+    sql_types::{Nullable, SingleValue},
+};
 use diesel_async::{pooled_connection::deadpool::Pool, AsyncPgConnection};
 use s3::interface::Storage;
 use serde::{Deserialize, Serialize};
@@ -20,6 +23,8 @@ pub mod schema;
 pub mod sessions;
 pub mod users;
 pub mod utils;
+
+sql_function! { fn coalesce<T: SingleValue>(x: Nullable<T>, y: T) -> T; }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use std::{fmt::Display, fs, sync::Arc};
 
 use axum::{extract::FromRef, response::IntoResponse};
 use diesel::{
+    allow_columns_to_appear_in_same_group_by_clause, sql_function,
     sql_types::{Nullable, SingleValue},
 };
 use diesel_async::{pooled_connection::deadpool::Pool, AsyncPgConnection};
@@ -25,6 +26,33 @@ pub mod users;
 pub mod utils;
 
 sql_function! { fn coalesce<T: SingleValue>(x: Nullable<T>, y: T) -> T; }
+
+allow_columns_to_appear_in_same_group_by_clause!(
+    crate::schema::comics::id,
+    crate::schema::comics::title,
+    crate::schema::comics::slug,
+    crate::schema::comics::description,
+    crate::schema::comics::created_at,
+    crate::schema::comics::updated_at,
+    crate::schema::comics::is_visible,
+    crate::schema::comics::published_at,
+    crate::schema::comics::poster_path,
+    crate::schema::comics::poster_content_type,
+    crate::schema::comics::user_id,
+    crate::schema::users::id,
+    crate::schema::users::first_name,
+    crate::schema::users::last_name,
+    crate::schema::users::username,
+    crate::schema::users::displayname,
+    crate::schema::users::email,
+    crate::schema::users::phone_number,
+    crate::schema::users::bio,
+    crate::schema::users::password,
+    crate::schema::users::role,
+    crate::schema::users::created_at,
+    crate::schema::users::updated_at,
+    crate::schema::users::last_login,
+);
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigError {
@@ -102,6 +130,7 @@ pub struct AppState {
         schemas(comics::models::CreateComic),
         schemas(comics::models::UpdateComic),
         schemas(comics::models::ComicResponse),
+        schemas(comics::models::ComicResponseBrief),
         schemas(comics::models::NewComicRating),
         schemas(comics::comic_genres::models::ComicGenre),
         schemas(comics::chapters::models::CreateChapter),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,8 @@ pub struct AppState {
         schemas(comics::models::ComicResponse),
         schemas(comics::models::ComicResponseBrief),
         schemas(comics::models::NewComicRating),
+        schemas(comics::models::ComicsPagination),
+        schemas(comics::models::Order),
         schemas(comics::comic_genres::models::ComicGenre),
         schemas(comics::chapters::models::CreateChapter),
         schemas(comics::chapters::models::UpdateChapter),

--- a/src/sessions/models.rs
+++ b/src/sessions/models.rs
@@ -7,6 +7,7 @@ use crate::schema::sessions;
 #[derive(Queryable, Selectable)]
 #[diesel(belongs_to(User))]
 #[diesel(table_name = sessions)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Session {
     pub id: Uuid,
     pub created_at: DateTime<chrono::Utc>,
@@ -16,6 +17,7 @@ pub struct Session {
 
 #[derive(Insertable)]
 #[diesel(table_name = sessions)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct CreateSession {
     pub id: Uuid,
     pub user_id: Uuid,

--- a/src/users/email_verifications/models.rs
+++ b/src/users/email_verifications/models.rs
@@ -7,6 +7,7 @@ use crate::schema::email_verifications;
 #[derive(Queryable, Selectable, Insertable, Debug, Identifiable)]
 #[diesel(belongs_to(User))]
 #[diesel(table_name = email_verifications)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct EmailVerification {
     pub id: Uuid,
     pub email: String,

--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -85,6 +85,18 @@ pub struct User {
     pub last_login: Option<NaiveDateTime>,
 }
 
+impl User {
+    pub fn into_response_brief(self) -> UserResponseBrief {
+        UserResponseBrief {
+            id: self.id,
+            displayname: self.displayname,
+            username: self.username,
+            email: self.email,
+            role: self.role,
+        }
+    }
+}
+
 #[derive(Insertable, Queryable, Identifiable, Associations, Selectable, Debug)]
 #[diesel(belongs_to(User))]
 #[diesel(table_name = profile_images)]

--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -68,6 +68,7 @@ impl FromSql<crate::schema::sql_types::Userrole, Pg> for UserRole {
 
 #[derive(Insertable, Queryable, Selectable, Identifiable, Debug)]
 #[diesel(table_name = users)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct User {
     pub id: Uuid,
     pub first_name: Option<String>,
@@ -87,6 +88,7 @@ pub struct User {
 #[derive(Insertable, Queryable, Identifiable, Associations, Selectable, Debug)]
 #[diesel(belongs_to(User))]
 #[diesel(table_name = profile_images)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ProfileImage {
     pub id: Uuid,
     pub path: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,9 @@
 use crate::Rating;
 
 pub fn average_rating<T: Rating>(ratings: Vec<T>) -> f64 {
-    ratings.iter().map(|r| r.rating()).sum::<f64>() / ratings.len() as f64
+    if ratings.is_empty() {
+        0.0
+    } else {
+        ratings.iter().map(|r| r.rating()).sum::<f64>() / ratings.len() as f64
+    }
 }


### PR DESCRIPTION
- comics can be ordered by rating or created_at column
- by default, comics are ordered by created_at column, in descending order
- it's possible to filter comics by genre, the join with the genre table will only happen when a filter is passed (previously we had to use distinct)
- no support for ascending orders